### PR TITLE
Fix JSON download buton and other fixes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>
-      ATAG Conformance Evaluation Report Tool | Web Accessibility Initiative
-      (WAI) | W3C
+      Framework for Accessible Specification of Technologies Tool | Web
+      Accessibility Initiative (WAI) | W3C
     </title>
     <link
       rel="stylesheet"

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,7 +1,7 @@
 <script>
   import { Router, Route } from "svelte-routing";
   import Start from "./routes/Start.svelte";
-  import YourEvaluation from './routes/YourEvaluation.svelte';
+  import YourReport from './routes/YourReport.svelte';
   import EvaluationInfo from './components/EvaluationInfo.svelte';
   import Results from "./routes/Results.svelte";
   import Principle from './components/Principle.svelte';
@@ -14,7 +14,7 @@
 <Progress>
   <Router>
     <ProgressItem to="/">Start</ProgressItem>
-    <ProgressItem to="/your-evaluation">Your Evaluation</ProgressItem>
+    <ProgressItem to="/your-report">Your Report</ProgressItem>
     {#each new_fast as { principle, guidelines }, i }
     <ProgressItem to="step/{i+1}">{principle.num}<span class="visuallyhidden">: {principle.handle}</span></ProgressItem>
     {/each}
@@ -27,8 +27,8 @@
     <Route path="/">
       <Start />
     </Route>
-    <Route path="/your-evaluation">
-      <YourEvaluation />
+    <Route path="/your-report">
+      <YourReport />
     </Route>
     <Route path="/step/:id" let:params>
       <Principle id="{params.id-1}" />

--- a/src/components/EvaluationInfo.svelte
+++ b/src/components/EvaluationInfo.svelte
@@ -9,7 +9,7 @@
   let fresh;
 
   function startNew() {
-    navigate('/your-evaluation', { replace: false });
+    navigate('/your-report', { replace: false });
   }
 
   function toOverview() {

--- a/src/components/Principle.svelte
+++ b/src/components/Principle.svelte
@@ -30,8 +30,9 @@
   </Header>
 
   <p>More details: <a href={linkToPrinciple} target="_blank" rel="noopener roreferrer">{principle.num} {principle.text}</a></p>
-  
-  {#each guidelines as guideline }
+
+   
+  {#each guidelines as guideline, i (guideline.id) }
   <Guideline {...guideline} />
   {/each}
 

--- a/src/components/Principle.svelte
+++ b/src/components/Principle.svelte
@@ -1,16 +1,21 @@
 <script>
-
+  import { onMount } from 'svelte';
   import Header from './Header.svelte';
   import HeaderSub from './HeaderSub.svelte';
   import Guideline from './Guideline.svelte';
   import Pager from './Pager.svelte';
   import PagerLink from './PagerLink.svelte';
   import new_fast from '../data/new_fast.js';
+  import { currentPage } from '../stores/currentPage.js';
   export let id = null;
   export let className = undefined;
 
   $: principle = new_fast[id].principle || null;
   $: guidelines = new_fast[id].guidelines || null;
+
+  onMount(() => {
+    currentPage.update( currentPage => 'Report' );
+  });
 
   const normalisedPrincipleId = new_fast[id].principle.num.replace(/\./g, '').toLowerCase();
   const linkToPrinciple = `https://w3c.github.io/apa/fast/#${normalisedPrincipleId}`;

--- a/src/components/Principle.svelte
+++ b/src/components/Principle.svelte
@@ -32,7 +32,7 @@
 
   <Pager label="Previous/Next Step">
     {#if id === 0}
-    <PagerLink to={"/your-evaluation"} direction="previous">Your Evaluation</PagerLink>
+    <PagerLink to={"/your-report"} direction="previous">Your Report</PagerLink>
     {/if}
     {#if id > 0 && id < new_fast.length }
     <PagerLink to={`/step/${id}`} direction="previous">

--- a/src/main.js
+++ b/src/main.js
@@ -11,14 +11,16 @@ const routerSettings = {
 
     if (location.pathname.startsWith("/step/")) {
       const id = location.pathname.substring(6, 7);
-      return (newTitle = `${new_fast[id - 1].principle.handle} - ${defaultTitle}`);
+      return (newTitle = `${
+        new_fast[id - 1].principle.handle
+      } - ${defaultTitle}`);
     }
 
     switch (location.pathname) {
       case "/":
         return (newTitle = `Start - ${defaultTitle}`);
-      case "/your-evaluation":
-        return (newTitle = `Your Evaluation - ${defaultTitle}`);
+      case "/your-report":
+        return (newTitle = `Your Report - ${defaultTitle}`);
       case "/results":
         return (newTitle = `Results - ${defaultTitle}`);
     }

--- a/src/routes/Results.svelte
+++ b/src/routes/Results.svelte
@@ -23,7 +23,7 @@
   Results
 </Header>
 <p>Thanks for using this tool. Your FAST evaluation is displayed in full below.</p>
-<p><a href={jsonDownload} class="button button-secondary">Download FAST evaluation (JSON)</a></p>
+<p><a href={jsonDownload} download="report.json" class="button button-secondary">Download FAST evaluation (JSON)</a></p>
 <dl>
   {#if $evaluation["meta"]["name"]["value"]}
   <dt>Name</dt>

--- a/src/routes/Results.svelte
+++ b/src/routes/Results.svelte
@@ -1,13 +1,19 @@
 <script>
+  import { onMount } from 'svelte';
   import marked from 'marked';
-  import { evaluation } from '../stores/evaluation.js';
   import Header from '../components/Header.svelte';
   import HeaderSub from '../components/HeaderSub.svelte';
+  import { evaluation } from '../stores/evaluation.js';
+  import { currentPage } from '../stores/currentPage.js';
 
   function createDownload(evaluation) {
     let blob = new Blob([JSON.stringify(evaluation)]);
     return url
   }
+
+  onMount(() => {
+    currentPage.update( currentPage => 'Results' );
+  });
 
   $: jsonDownload = `data:application/json;charset=utf-8,${encodeURIComponent(JSON.stringify($evaluation))}`;
 </script>

--- a/src/routes/Start.svelte
+++ b/src/routes/Start.svelte
@@ -1,8 +1,14 @@
 <script>
+  import { onMount } from 'svelte';
   import ExpandCollapseAll from '../components/ExpandCollapseAll.svelte';
   import Header from '../components/Header.svelte';
   import Pager from '../components/Pager.svelte';
   import PagerLink from '../components/PagerLink.svelte';
+  import { currentPage } from '../stores/currentPage.js';
+
+  onMount(() => {
+    currentPage.update( currentPage => 'Start' );
+  });
 </script>
 
 <Header>FAST Report Tool</Header>

--- a/src/routes/Start.svelte
+++ b/src/routes/Start.svelte
@@ -52,5 +52,5 @@
 </details>
 
 <Pager label="Previous/Next Step">
-  <PagerLink to="/your-evaluation" direction="next">Your evaluation</PagerLink>
+  <PagerLink to="/your-report" direction="next">Your Report</PagerLink>
 </Pager>

--- a/src/routes/YourReport.svelte
+++ b/src/routes/YourReport.svelte
@@ -1,21 +1,27 @@
 <script>
+  import { onMount } from 'svelte';
   import Header from '../components/Header.svelte';
   import HeaderSub from '../components/HeaderSub.svelte';
   import Pager from '../components/Pager.svelte';
   import PagerLink from '../components/PagerLink.svelte';
   import { evaluation } from '../stores/evaluation.js';
+  import { currentPage } from '../stores/currentPage.js';
+
+  onMount(() => {
+    currentPage.update( currentPage => 'Your Report' );
+  });
 </script>
 
 <Header>
   <HeaderSub>
     FAST Report Tool
   </HeaderSub>
-  Your Evaluation
+  Your Report
 </Header>
 
 <p>On this page, you can set up your evaluation.</p>
 
-<h2>About your evaluation</h2>
+<h2>About your report</h2>
 
 <div class="field">
   <label for="evaluation-meta-name">Name of W3C specification</label>

--- a/src/stores/currentPage.js
+++ b/src/stores/currentPage.js
@@ -1,0 +1,3 @@
+import { writable } from "svelte/store";
+
+export const currentPage = writable(0);

--- a/src/utils/getEvaluatedItems.js
+++ b/src/utils/getEvaluatedItems.js
@@ -1,0 +1,13 @@
+export function getEvaluatedItems(evaluation) {
+  if (
+    evaluation &&
+    evaluation.evaluationData &&
+    Object.keys(evaluation.evaluationData).length > 0
+  ) {
+    return Object.values(evaluation.evaluationData).filter(
+      item => item.evaluated === true
+    );
+  } else {
+    return [];
+  }
+}

--- a/src/utils/importEvaluation.js
+++ b/src/utils/importEvaluation.js
@@ -1,0 +1,34 @@
+import { evaluation } from "../stores/evaluation.js";
+
+export function importEvaluation(event) {
+  var files = event.target.files;
+
+  for (var i = 0, file; (file = files[i]); i++) {
+    if (!file.type.match("application/json")) {
+      return;
+    }
+
+    var reader = new FileReader();
+
+    reader.onload = function(event) {
+      try {
+        var converted = JSON.parse(event.target.result);
+
+        if (converted.evaluationData) {
+          evaluation.update(evaluation => converted);
+
+          if (converted.meta.name.value) {
+            alert(`Report “${converted.meta.name.value}” loaded`);
+          } else {
+            alert("Report loaded");
+          }
+          startedNew = true;
+        }
+      } catch {
+        alert("No data found or invalid import");
+      }
+    };
+
+    reader.readAsText(file);
+  }
+}


### PR DESCRIPTION
Hi @RealJoshue108,

This ensures the JSON download button actually triggers a file to be downloaded.

It also uses the most recent version of the “evaluation box” on the left, that is less confusing, and updates the initial page title to have ATAG replaced by FAST. 

Lastly it fixes a bug that accidentally populated result choices for the next page. 